### PR TITLE
chore: release 0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g. 0.2.0 — without the v prefix)"
+        description: "Version to release (e.g. 0.2.0 — must already be set in Cargo.toml)"
         required: true
         type: string
 
@@ -29,59 +29,60 @@ jobs:
       - run: cargo clippy --features full,serde -- -Dclippy::all
       - run: cargo test --features full,serde
 
-  # ── Bump version, commit, tag ─────────────────────────────────────────────
-  bump:
-    name: bump version
+  # ── Verify Cargo.toml version matches input ───────────────────────────────
+  verify-version:
+    name: verify version
     runs-on: ubuntu-latest
     needs: preflight
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Cargo.toml version matches input
+        run: |
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['packages'][0]['version'])")
+          INPUT_VERSION="${{ inputs.version }}"
+          echo "Cargo.toml: $CARGO_VERSION"
+          echo "Input:      $INPUT_VERSION"
+          if [ "$CARGO_VERSION" != "$INPUT_VERSION" ]; then
+            echo "::error::Version mismatch — bump Cargo.toml to $INPUT_VERSION in a PR first."
+            exit 1
+          fi
+
+  # ── Create and push tag ───────────────────────────────────────────────────
+  tag:
+    name: tag
+    runs-on: ubuntu-latest
+    needs: verify-version
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Use a PAT so the push triggers downstream workflows
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Bump version in Cargo.toml
-        run: |
-          VERSION="${{ inputs.version }}"
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-          # Verify the change
-          grep "^version" Cargo.toml
-
-      - name: Update Cargo.lock
-        run: cargo update --workspace
-
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit and tag
+      - name: Create and push tag
         id: tag
         run: |
           TAG="v${{ inputs.version }}"
-          git add Cargo.toml Cargo.lock
-          if git diff --cached --quiet; then
-            echo "Version already set to ${{ inputs.version }}, skipping commit."
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping."
           else
-            git commit -m "chore: release $TAG"
-            git push origin main
+            git tag "$TAG"
+            git push origin "$TAG"
           fi
-          git tag "$TAG"
-          git push origin "$TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
   # ── Publish to crates.io ──────────────────────────────────────────────────
   publish:
     name: publish
     runs-on: ubuntu-latest
-    needs: bump
+    needs: tag
     environment: crates-io
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.bump.outputs.tag }}
+          ref: ${{ needs.tag.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: cargo publish
@@ -93,14 +94,14 @@ jobs:
   github-release:
     name: github-release
     runs-on: ubuntu-latest
-    needs: [bump, publish]
+    needs: [tag, publish]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.bump.outputs.tag }}
+          ref: ${{ needs.tag.outputs.tag }}
           fetch-depth: 0
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.bump.outputs.tag }}
+          tag_name: ${{ needs.tag.outputs.tag }}
           generate_release_notes: true
           make_latest: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.1.1] — 2026-04-17
+
 ### Added
 
 - `CountryCode` value object — ISO 3166-1 alpha-2, normalised to uppercase
 - `PhoneNumber` composite value object — `CountryCode` + local number → canonical E.164; ITU calling codes for all 249 ISO 3166-1 countries
 - `EmailAddress::domain()` and `EmailAddress::local_part()` accessors
+- `docs/` folder with reference documentation: `value-objects.md`, `implementing.md`, `contact.md`
 
 ### Changed
 
 - `ValueObject` trait: `Raw` split into `Input` (accepted by `new()`) and `Output` (returned by `value()`), enabling composite types with structured input and canonical string output
-- `EmailAddress` and `CountryCode` updated to use `EmailAddressInput`/`Output` and `CountryCodeInput`/`Output` type aliases
+- `EmailAddress` and `CountryCode` updated to use type aliases (`EmailAddressInput`/`Output`, `CountryCodeInput`/`Output`)
+- Release workflow redesigned — version bump goes through PR, workflow only tags and publishes
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arvo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arvo"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 description = "Validated, immutable value objects for common domain types (email, money, identifiers, …)"
 authors = ["Codegress <hello@codegress.com>"]


### PR DESCRIPTION
## Summary

Release bump to v0.1.1. Fixes the release workflow so it no longer pushes a version commit directly to `main` (which was blocked by branch protection) — the version bump now goes through a normal PR instead.

## Type of change

- [ ] Bug fix
- [ ] New value object / feature
- [ ] Documentation
- [ ] Refactor / internal improvement
- [x] CI / tooling

## Checklist

- [x] `cargo fmt` — code is formatted
- [x] `cargo clippy --features full,serde -- -Dclippy::all` — no warnings
- [x] `cargo test --features full,serde` — all tests pass
- [ ] New public API has doc comments with an `# Example` block
- [ ] New value objects have tests for: valid input, empty input, invalid format, normalisation
- [ ] README feature table updated (if a new feature was added)
