### PR TITLE
Add temporal module (v0.6.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = "2"
 once_cell = { version = "1", optional = true }
 regex = { version = "1", optional = true }
 rust_decimal = { version = "1.26", optional = true }
-chrono = { version = "0.4", optional = true, features = ["serde"] }
+chrono = { version = "0.4.23", optional = true, features = ["serde"] }
 uuid = { version = "1", optional = true, features = ["v4"] }
 ulid = { version = "1", optional = true }
 url = { version = "~2.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ contact = ["dep:once_cell", "dep:regex", "dep:url"]
 finance = ["dep:rust_decimal", "dep:chrono"]
 identifiers = []
 primitives = ["dep:rust_decimal", "dep:base64"]
+temporal = ["dep:chrono"]
 
 # Cross-cutting concerns can be combined with any module
 serde = ["dep:serde"]
@@ -33,6 +34,7 @@ full = [
     "finance",
     "identifiers",
     "primitives",
+    "temporal",
 ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ let email: EmailAddress = "user@example.com".try_into()?;
 | [docs/finance.md](docs/finance.md) | Reference for all `finance` module types |
 | [docs/identifiers.md](docs/identifiers.md) | Reference for all `identifiers` module types |
 | [docs/primitives.md](docs/primitives.md) | Reference for all `primitives` module types |
+| [docs/temporal.md](docs/temporal.md) | Reference for all `temporal` module types |
 
 ---
 
@@ -70,6 +71,7 @@ Enable only the modules you need — unused features add zero dependencies.
 | `finance` | `Money`, `CurrencyCode`, `Iban`, `Bic`, `VatNumber`, `Percentage`, `ExchangeRate`, `CreditCardNumber`, `CardExpiryDate` | `rust_decimal`, `chrono` |
 | `identifiers` | `Slug`, `Ean13`, `Ean8`, `Isbn13`, `Isbn10`, `Issn`, `Vin` | — |
 | `primitives` | `NonEmptyString`, `BoundedString`, `PositiveInt`, `NonNegativeInt`, `PositiveDecimal`, `NonNegativeDecimal`, `Probability`, `HexColor`, `Locale`, `Base64String` | `rust_decimal`, `base64` |
+| `temporal` | `UnixTimestamp`, `BirthDate`, `ExpiryDate`, `TimeRange`, `BusinessHours` | `chrono` |
 | `serde` | `Serialize` / `Deserialize` on all types | `serde` |
 | `full` | All domain modules | all of the above |
 
@@ -204,7 +206,7 @@ let parsed: EmailAddress = serde_json::from_str(r#""hello@example.com""#)?;
 | `contact` | `EmailAddress`, `PhoneNumber`, `CountryCode`, `PostalAddress`, `Website` | 5 | 5 / 5 ✅ |
 | `identifiers` | `Slug`, `Ean13`, `Isbn13`, `Vin` | 7 | 7 / 7 ✅ |
 | `finance` | `Money`, `CurrencyCode`, `Iban`, `Bic`, `VatNumber`, `Percentage`, `ExchangeRate`, `CreditCardNumber`, `CardExpiryDate` | 9 | 9 / 9 ✅ |
-| `temporal` | `BirthDate`, `ExpiryDate`, `TimeRange`, `BusinessHours` | 5 | 0 / 5 |
+| `temporal` | `UnixTimestamp`, `BirthDate`, `ExpiryDate`, `TimeRange`, `BusinessHours` | 5 | 5 / 5 ✅ |
 | `geo` | `Latitude`, `Longitude`, `Coordinate`, `BoundingBox`, `TimeZone` | 6 | 0 / 6 |
 | `net` | `Url`, `IpAddress`, `MacAddress`, `ApiKey`, `Port` | 10 | 0 / 10 |
 | `measurement` | `Length`, `Weight`, `Temperature`, `Speed` ⚠️ needs unit conversion design | 10 | 0 / 10 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,11 +56,11 @@
 
 | Type | Status | Notes |
 |---|---|---|
-| `UnixTimestamp` | ⬜ | non-negative `i64` seconds since epoch |
-| `BirthDate` | ⬜ | date in the past, not more than 150 years ago |
-| `ExpiryDate` | ⬜ | date strictly in the future |
-| `TimeRange` | ⬜ | start + end `DateTime`; `start < end` enforced |
-| `BusinessHours` | ⬜ | composite: weekday + open time + close time; open < close |
+| `UnixTimestamp` | ✅ | non-negative `i64` seconds since epoch |
+| `BirthDate` | ✅ | date in the past, not more than 150 years ago |
+| `ExpiryDate` | ✅ | date strictly in the future |
+| `TimeRange` | ✅ | start + end `DateTime`; `start < end` enforced |
+| `BusinessHours` | ✅ | composite: weekday + open time + close time; open < close |
 
 ---
 
@@ -137,9 +137,9 @@
 | `contact` | 5 | 5 | 0 |
 | `identifiers` | 7 | 7 | 0 |
 | `finance` | 9 | 9 | 0 |
-| `temporal` | 5 | 0 | 5 |
+| `temporal` | 5 | 5 | 0 |
 | `geo` | 6 | 0 | 6 |
 | `net` | 10 | 0 | 10 |
 | `measurement` | 10 | 0 | 10 |
 | `primitives` | 10 | 10 | 0 |
-| **Total** | **62** | **31** | **31** |
+| **Total** | **62** | **36** | **26** |

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -1,0 +1,179 @@
+# temporal module
+
+Feature flag: `temporal`
+
+```toml
+[dependencies]
+arvo = { version = "0.6", features = ["temporal"] }
+```
+
+---
+
+## UnixTimestamp
+
+A validated Unix timestamp — non-negative seconds since the Unix epoch (1970-01-01T00:00:00Z).
+
+**Normalisation:** none.  
+**Validation:** must be `>= 0`.
+
+```rust,ignore
+use arvo::temporal::UnixTimestamp;
+use arvo::traits::ValueObject;
+
+let ts = UnixTimestamp::new(1_700_000_000).unwrap();
+assert_eq!(*ts.value(), 1_700_000_000);
+
+assert!(UnixTimestamp::new(-1).is_err());
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&i64` | `1700000000` |
+| `into_inner()` | `i64` | `1700000000` |
+
+---
+
+## BirthDate
+
+A validated date of birth — strictly in the past and no more than 150 years ago.
+
+**Normalisation:** none.  
+**Input / Output:** `chrono::NaiveDate`.
+
+```rust,ignore
+use arvo::temporal::BirthDate;
+use arvo::traits::ValueObject;
+use chrono::NaiveDate;
+
+let dob = BirthDate::new(NaiveDate::from_ymd_opt(1990, 6, 15).unwrap()).unwrap();
+assert_eq!(dob.value().year(), 1990);
+assert!(dob.age_years() > 0);
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&NaiveDate` | `1990-06-15` |
+| `age_years()` | `u32` | `35` |
+| `into_inner()` | `NaiveDate` | — |
+
+### Errors
+
+| Condition | Error |
+|---|---|
+| date is today or in the future | `ValidationError::InvalidFormat` |
+| date is more than 150 years ago | `ValidationError::InvalidFormat` |
+
+---
+
+## ExpiryDate
+
+A validated expiry date — strictly in the future at construction time.
+
+**Normalisation:** none.  
+**Input / Output:** `chrono::NaiveDate`.
+
+```rust,ignore
+use arvo::temporal::ExpiryDate;
+use arvo::traits::ValueObject;
+use chrono::NaiveDate;
+
+let exp = ExpiryDate::new(NaiveDate::from_ymd_opt(2030, 12, 31).unwrap()).unwrap();
+assert!(exp.days_until() > 0);
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&NaiveDate` | `2030-12-31` |
+| `days_until()` | `i64` | `1715` |
+| `into_inner()` | `NaiveDate` | — |
+
+### Errors
+
+| Condition | Error |
+|---|---|
+| date is today or in the past | `ValidationError::InvalidFormat` |
+
+---
+
+## TimeRange
+
+A validated time range — `start` must be strictly before `end`.
+
+**Normalisation:** none.  
+**Input:** `TimeRangeInput { start: DateTime<Utc>, end: DateTime<Utc> }`.  
+**Output:** canonical `"<start> / <end>"` string.
+
+```rust,ignore
+use arvo::temporal::{TimeRange, TimeRangeInput};
+use arvo::traits::ValueObject;
+use chrono::{TimeZone, Utc};
+
+let range = TimeRange::new(TimeRangeInput {
+    start: Utc.with_ymd_and_hms(2025, 1, 1, 10, 0, 0).unwrap(),
+    end:   Utc.with_ymd_and_hms(2025, 1, 1, 12, 0, 0).unwrap(),
+})?;
+assert_eq!(range.duration().num_hours(), 2);
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"2025-01-01 10:00:00 UTC / 2025-01-01 12:00:00 UTC"` |
+| `start()` | `&DateTime<Utc>` | — |
+| `end()` | `&DateTime<Utc>` | — |
+| `duration()` | `Duration` | `2h` |
+| `into_inner()` | `TimeRangeInput` | — |
+
+### Errors
+
+| Condition | Error |
+|---|---|
+| `start >= end` | `ValidationError::InvalidFormat` |
+
+---
+
+## BusinessHours
+
+Validated business hours for a single weekday — `open` must be strictly before `close`.
+
+**Normalisation:** none.  
+**Input:** `BusinessHoursInput { weekday: Weekday, open: NaiveTime, close: NaiveTime }`.  
+**Output:** canonical `"<Day> HH:MM–HH:MM"` string.
+
+```rust,ignore
+use arvo::temporal::{BusinessHours, BusinessHoursInput};
+use arvo::traits::ValueObject;
+use chrono::{NaiveTime, Weekday};
+
+let hours = BusinessHours::new(BusinessHoursInput {
+    weekday: Weekday::Mon,
+    open:    NaiveTime::from_hms_opt(9, 0, 0).unwrap(),
+    close:   NaiveTime::from_hms_opt(17, 0, 0).unwrap(),
+})?;
+assert_eq!(hours.value(), "Mon 09:00–17:00");
+assert_eq!(hours.duration().num_hours(), 8);
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"Mon 09:00–17:00"` |
+| `weekday()` | `Weekday` | `Weekday::Mon` |
+| `open()` | `&NaiveTime` | `09:00` |
+| `close()` | `&NaiveTime` | `17:00` |
+| `duration()` | `Duration` | `8h` |
+| `into_inner()` | `BusinessHoursInput` | — |
+
+### Errors
+
+| Condition | Error |
+|---|---|
+| `open >= close` | `ValidationError::InvalidFormat` |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ pub mod identifiers;
 #[cfg(feature = "primitives")]
 pub mod primitives;
 
+#[cfg(feature = "temporal")]
+pub mod temporal;
+
 /// Convenience re-exports for the most commonly used types.
 ///
 /// Add `use arvo::prelude::*;` to bring the `ValueObject` trait and

--- a/src/temporal/birth_date.rs
+++ b/src/temporal/birth_date.rs
@@ -1,0 +1,139 @@
+use chrono::{Datelike, Local, NaiveDate};
+
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`BirthDate`].
+pub type BirthDateInput = NaiveDate;
+
+/// Output type for [`BirthDate`].
+pub type BirthDateOutput = NaiveDate;
+
+/// A validated date of birth.
+///
+/// The date must be strictly in the past and no more than 150 years before
+/// today at construction time.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::temporal::BirthDate;
+/// use arvo::traits::ValueObject;
+/// use chrono::NaiveDate;
+///
+/// let dob = BirthDate::new(NaiveDate::from_ymd_opt(1990, 6, 15).unwrap()).unwrap();
+/// assert_eq!(dob.value().year(), 1990);
+/// assert!(dob.age_years() > 0);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct BirthDate(NaiveDate);
+
+impl ValueObject for BirthDate {
+    type Input = BirthDateInput;
+    type Output = BirthDateOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let today = Local::now().date_naive();
+
+        if value >= today {
+            return Err(ValidationError::invalid("BirthDate", &value.to_string()));
+        }
+
+        let min_date = today
+            .with_year(today.year() - 150)
+            .unwrap_or(NaiveDate::from_ymd_opt(today.year() - 150, today.month(), 1).unwrap());
+
+        if value < min_date {
+            return Err(ValidationError::invalid("BirthDate", &value.to_string()));
+        }
+
+        Ok(Self(value))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl BirthDate {
+    /// Returns the person's age in full completed years as of today.
+    pub fn age_years(&self) -> u32 {
+        let today = Local::now().date_naive();
+        let years = today.year() - self.0.year();
+        let had_birthday = (today.month(), today.day()) >= (self.0.month(), self.0.day());
+        if had_birthday {
+            years as u32
+        } else {
+            (years - 1) as u32
+        }
+    }
+}
+
+impl std::fmt::Display for BirthDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn past_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(1990, 6, 15).unwrap()
+    }
+
+    #[test]
+    fn accepts_past_date() {
+        assert!(BirthDate::new(past_date()).is_ok());
+    }
+
+    #[test]
+    fn value_returns_date() {
+        let d = BirthDate::new(past_date()).unwrap();
+        assert_eq!(*d.value(), past_date());
+    }
+
+    #[test]
+    fn rejects_today() {
+        let today = Local::now().date_naive();
+        assert!(BirthDate::new(today).is_err());
+    }
+
+    #[test]
+    fn rejects_future() {
+        let future = Local::now().date_naive() + chrono::Duration::days(1);
+        assert!(BirthDate::new(future).is_err());
+    }
+
+    #[test]
+    fn rejects_too_old() {
+        let ancient = NaiveDate::from_ymd_opt(1800, 1, 1).unwrap();
+        assert!(BirthDate::new(ancient).is_err());
+    }
+
+    #[test]
+    fn age_years_positive() {
+        let d = BirthDate::new(past_date()).unwrap();
+        assert!(d.age_years() > 0);
+    }
+
+    #[test]
+    fn display_is_iso_date() {
+        let d = BirthDate::new(past_date()).unwrap();
+        assert_eq!(d.to_string(), "1990-06-15");
+    }
+
+    #[test]
+    fn into_inner_roundtrip() {
+        let d = BirthDate::new(past_date()).unwrap();
+        assert_eq!(d.into_inner(), past_date());
+    }
+}

--- a/src/temporal/business_hours.rs
+++ b/src/temporal/business_hours.rs
@@ -1,0 +1,246 @@
+use chrono::{Duration, NaiveTime, Timelike, Weekday};
+
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`BusinessHours`] construction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BusinessHoursInput {
+    /// Day of the week.
+    pub weekday: Weekday,
+    /// Opening time — must be strictly before `close`.
+    pub open: NaiveTime,
+    /// Closing time — must be strictly after `open`.
+    pub close: NaiveTime,
+}
+
+/// Output type for [`BusinessHours`] — canonical `"<Day> HH:MM–HH:MM"` string.
+pub type BusinessHoursOutput = String;
+
+/// Validated business hours for a single weekday.
+///
+/// `open` must be strictly before `close`. The canonical output is formatted
+/// as `"<Day> HH:MM–HH:MM"`, e.g. `"Mon 09:00–17:00"`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::temporal::{BusinessHours, BusinessHoursInput};
+/// use arvo::traits::ValueObject;
+/// use chrono::{NaiveTime, Weekday};
+///
+/// let hours = BusinessHours::new(BusinessHoursInput {
+///     weekday: Weekday::Mon,
+///     open:    NaiveTime::from_hms_opt(9, 0, 0).unwrap(),
+///     close:   NaiveTime::from_hms_opt(17, 0, 0).unwrap(),
+/// }).unwrap();
+///
+/// assert_eq!(hours.value(), "Mon 09:00–17:00");
+/// assert_eq!(hours.duration().num_hours(), 8);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BusinessHours {
+    weekday: Weekday,
+    open: NaiveTime,
+    close: NaiveTime,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    canonical: String,
+}
+
+impl ValueObject for BusinessHours {
+    type Input = BusinessHoursInput;
+    type Output = BusinessHoursOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        if value.open >= value.close {
+            return Err(ValidationError::invalid(
+                "BusinessHours",
+                &format!(
+                    "{} {}–{}",
+                    weekday_abbr(value.weekday),
+                    value.open,
+                    value.close
+                ),
+            ));
+        }
+
+        let canonical = format!(
+            "{} {:02}:{:02}–{:02}:{:02}",
+            weekday_abbr(value.weekday),
+            value.open.hour(),
+            value.open.minute(),
+            value.close.hour(),
+            value.close.minute(),
+        );
+
+        Ok(Self {
+            weekday: value.weekday,
+            open: value.open,
+            close: value.close,
+            canonical,
+        })
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.canonical
+    }
+
+    fn into_inner(self) -> Self::Input {
+        BusinessHoursInput {
+            weekday: self.weekday,
+            open: self.open,
+            close: self.close,
+        }
+    }
+}
+
+impl BusinessHours {
+    /// Returns the weekday.
+    pub fn weekday(&self) -> Weekday {
+        self.weekday
+    }
+
+    /// Returns the opening time.
+    pub fn open(&self) -> &NaiveTime {
+        &self.open
+    }
+
+    /// Returns the closing time.
+    pub fn close(&self) -> &NaiveTime {
+        &self.close
+    }
+
+    /// Returns the duration of the business day (`close - open`).
+    pub fn duration(&self) -> Duration {
+        self.close - self.open
+    }
+}
+
+impl std::fmt::Display for BusinessHours {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.canonical)
+    }
+}
+
+fn weekday_abbr(wd: Weekday) -> &'static str {
+    match wd {
+        Weekday::Mon => "Mon",
+        Weekday::Tue => "Tue",
+        Weekday::Wed => "Wed",
+        Weekday::Thu => "Thu",
+        Weekday::Fri => "Fri",
+        Weekday::Sat => "Sat",
+        Weekday::Sun => "Sun",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open() -> NaiveTime {
+        NaiveTime::from_hms_opt(9, 0, 0).unwrap()
+    }
+
+    fn close() -> NaiveTime {
+        NaiveTime::from_hms_opt(17, 0, 0).unwrap()
+    }
+
+    fn valid_input() -> BusinessHoursInput {
+        BusinessHoursInput {
+            weekday: Weekday::Mon,
+            open: open(),
+            close: close(),
+        }
+    }
+
+    #[test]
+    fn accepts_valid_hours() {
+        let h = BusinessHours::new(valid_input()).unwrap();
+        assert_eq!(h.value(), "Mon 09:00–17:00");
+    }
+
+    #[test]
+    fn weekday_accessor() {
+        let h = BusinessHours::new(valid_input()).unwrap();
+        assert_eq!(h.weekday(), Weekday::Mon);
+    }
+
+    #[test]
+    fn open_accessor() {
+        let h = BusinessHours::new(valid_input()).unwrap();
+        assert_eq!(h.open(), &open());
+    }
+
+    #[test]
+    fn close_accessor() {
+        let h = BusinessHours::new(valid_input()).unwrap();
+        assert_eq!(h.close(), &close());
+    }
+
+    #[test]
+    fn duration_is_eight_hours() {
+        let h = BusinessHours::new(valid_input()).unwrap();
+        assert_eq!(h.duration().num_hours(), 8);
+    }
+
+    #[test]
+    fn rejects_equal_open_close() {
+        assert!(
+            BusinessHours::new(BusinessHoursInput {
+                weekday: Weekday::Mon,
+                open: open(),
+                close: open(),
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_open_after_close() {
+        assert!(
+            BusinessHours::new(BusinessHoursInput {
+                weekday: Weekday::Mon,
+                open: close(),
+                close: open(),
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn formats_all_weekdays() {
+        for (wd, abbr) in [
+            (Weekday::Mon, "Mon"),
+            (Weekday::Tue, "Tue"),
+            (Weekday::Wed, "Wed"),
+            (Weekday::Thu, "Thu"),
+            (Weekday::Fri, "Fri"),
+            (Weekday::Sat, "Sat"),
+            (Weekday::Sun, "Sun"),
+        ] {
+            let h = BusinessHours::new(BusinessHoursInput {
+                weekday: wd,
+                open: open(),
+                close: close(),
+            })
+            .unwrap();
+            assert!(h.value().starts_with(abbr));
+        }
+    }
+
+    #[test]
+    fn display_matches_value() {
+        let h = BusinessHours::new(valid_input()).unwrap();
+        assert_eq!(h.to_string(), h.value().to_owned());
+    }
+
+    #[test]
+    fn into_inner_roundtrip() {
+        let input = valid_input();
+        let h = BusinessHours::new(input.clone()).unwrap();
+        assert_eq!(h.into_inner(), input);
+    }
+}

--- a/src/temporal/expiry_date.rs
+++ b/src/temporal/expiry_date.rs
@@ -1,0 +1,117 @@
+use chrono::{Local, NaiveDate};
+
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`ExpiryDate`].
+pub type ExpiryDateInput = NaiveDate;
+
+/// Output type for [`ExpiryDate`].
+pub type ExpiryDateOutput = NaiveDate;
+
+/// A validated expiry date that is strictly in the future.
+///
+/// The date must be after today at construction time.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::temporal::ExpiryDate;
+/// use arvo::traits::ValueObject;
+/// use chrono::NaiveDate;
+///
+/// let exp = ExpiryDate::new(NaiveDate::from_ymd_opt(2030, 12, 31).unwrap()).unwrap();
+/// assert!(exp.days_until() > 0);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct ExpiryDate(NaiveDate);
+
+impl ValueObject for ExpiryDate {
+    type Input = ExpiryDateInput;
+    type Output = ExpiryDateOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let today = Local::now().date_naive();
+
+        if value <= today {
+            return Err(ValidationError::invalid("ExpiryDate", &value.to_string()));
+        }
+
+        Ok(Self(value))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl ExpiryDate {
+    /// Returns the number of days from today until the expiry date.
+    pub fn days_until(&self) -> i64 {
+        let today = Local::now().date_naive();
+        (self.0 - today).num_days()
+    }
+}
+
+impl std::fmt::Display for ExpiryDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn future_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2030, 12, 31).unwrap()
+    }
+
+    #[test]
+    fn accepts_future_date() {
+        assert!(ExpiryDate::new(future_date()).is_ok());
+    }
+
+    #[test]
+    fn value_returns_date() {
+        let d = ExpiryDate::new(future_date()).unwrap();
+        assert_eq!(*d.value(), future_date());
+    }
+
+    #[test]
+    fn rejects_today() {
+        let today = Local::now().date_naive();
+        assert!(ExpiryDate::new(today).is_err());
+    }
+
+    #[test]
+    fn rejects_past() {
+        let past = NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
+        assert!(ExpiryDate::new(past).is_err());
+    }
+
+    #[test]
+    fn days_until_positive() {
+        let d = ExpiryDate::new(future_date()).unwrap();
+        assert!(d.days_until() > 0);
+    }
+
+    #[test]
+    fn display_is_iso_date() {
+        let d = ExpiryDate::new(future_date()).unwrap();
+        assert_eq!(d.to_string(), "2030-12-31");
+    }
+
+    #[test]
+    fn into_inner_roundtrip() {
+        let d = ExpiryDate::new(future_date()).unwrap();
+        assert_eq!(d.into_inner(), future_date());
+    }
+}

--- a/src/temporal/mod.rs
+++ b/src/temporal/mod.rs
@@ -1,0 +1,11 @@
+mod birth_date;
+mod business_hours;
+mod expiry_date;
+mod time_range;
+mod unix_timestamp;
+
+pub use birth_date::{BirthDate, BirthDateInput, BirthDateOutput};
+pub use business_hours::{BusinessHours, BusinessHoursInput, BusinessHoursOutput};
+pub use expiry_date::{ExpiryDate, ExpiryDateInput, ExpiryDateOutput};
+pub use time_range::{TimeRange, TimeRangeInput, TimeRangeOutput};
+pub use unix_timestamp::{UnixTimestamp, UnixTimestampInput, UnixTimestampOutput};

--- a/src/temporal/time_range.rs
+++ b/src/temporal/time_range.rs
@@ -1,0 +1,198 @@
+use chrono::{DateTime, Duration, Utc};
+
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`TimeRange`] construction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TimeRangeInput {
+    /// Start of the range (inclusive).
+    pub start: DateTime<Utc>,
+    /// End of the range (exclusive).
+    pub end: DateTime<Utc>,
+}
+
+/// Output type for [`TimeRange`] — canonical `"<start> / <end>"` string.
+pub type TimeRangeOutput = String;
+
+/// A validated time range with a start strictly before its end.
+///
+/// Both `start` and `end` are `chrono::DateTime<Utc>`. The canonical output
+/// is formatted as `"<start> / <end>"` in RFC 3339 format.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::temporal::{TimeRange, TimeRangeInput};
+/// use arvo::traits::ValueObject;
+/// use chrono::{TimeZone, Utc};
+///
+/// let range = TimeRange::new(TimeRangeInput {
+///     start: Utc.with_ymd_and_hms(2025, 1, 1, 10, 0, 0).unwrap(),
+///     end:   Utc.with_ymd_and_hms(2025, 1, 1, 12, 0, 0).unwrap(),
+/// }).unwrap();
+///
+/// assert_eq!(range.value(), "2025-01-01 10:00:00 UTC / 2025-01-01 12:00:00 UTC");
+/// assert_eq!(range.duration().num_hours(), 2);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TimeRange {
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    canonical: String,
+}
+
+impl ValueObject for TimeRange {
+    type Input = TimeRangeInput;
+    type Output = TimeRangeOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        if value.start >= value.end {
+            return Err(ValidationError::invalid(
+                "TimeRange",
+                &format!("{} / {}", value.start, value.end),
+            ));
+        }
+
+        let canonical = format!("{} / {}", value.start, value.end);
+        Ok(Self {
+            start: value.start,
+            end: value.end,
+            canonical,
+        })
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.canonical
+    }
+
+    fn into_inner(self) -> Self::Input {
+        TimeRangeInput {
+            start: self.start,
+            end: self.end,
+        }
+    }
+}
+
+impl TimeRange {
+    /// Returns the start of the range.
+    pub fn start(&self) -> &DateTime<Utc> {
+        &self.start
+    }
+
+    /// Returns the end of the range.
+    pub fn end(&self) -> &DateTime<Utc> {
+        &self.end
+    }
+
+    /// Returns the duration of the range (`end - start`).
+    pub fn duration(&self) -> Duration {
+        self.end - self.start
+    }
+}
+
+impl std::fmt::Display for TimeRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.canonical)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn start() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2025, 1, 1, 10, 0, 0).unwrap()
+    }
+
+    fn end() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2025, 1, 1, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn accepts_valid_range() {
+        assert!(
+            TimeRange::new(TimeRangeInput {
+                start: start(),
+                end: end()
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn start_accessor() {
+        let r = TimeRange::new(TimeRangeInput {
+            start: start(),
+            end: end(),
+        })
+        .unwrap();
+        assert_eq!(r.start(), &start());
+    }
+
+    #[test]
+    fn end_accessor() {
+        let r = TimeRange::new(TimeRangeInput {
+            start: start(),
+            end: end(),
+        })
+        .unwrap();
+        assert_eq!(r.end(), &end());
+    }
+
+    #[test]
+    fn duration_is_two_hours() {
+        let r = TimeRange::new(TimeRangeInput {
+            start: start(),
+            end: end(),
+        })
+        .unwrap();
+        assert_eq!(r.duration().num_hours(), 2);
+    }
+
+    #[test]
+    fn rejects_equal_start_end() {
+        assert!(
+            TimeRange::new(TimeRangeInput {
+                start: start(),
+                end: start()
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_start_after_end() {
+        assert!(
+            TimeRange::new(TimeRangeInput {
+                start: end(),
+                end: start()
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn display_matches_value() {
+        let r = TimeRange::new(TimeRangeInput {
+            start: start(),
+            end: end(),
+        })
+        .unwrap();
+        assert_eq!(r.to_string(), r.value().to_owned());
+    }
+
+    #[test]
+    fn into_inner_roundtrip() {
+        let input = TimeRangeInput {
+            start: start(),
+            end: end(),
+        };
+        let r = TimeRange::new(input.clone()).unwrap();
+        assert_eq!(r.into_inner(), input);
+    }
+}

--- a/src/temporal/unix_timestamp.rs
+++ b/src/temporal/unix_timestamp.rs
@@ -1,0 +1,92 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`UnixTimestamp`].
+pub type UnixTimestampInput = i64;
+
+/// Output type for [`UnixTimestamp`].
+pub type UnixTimestampOutput = i64;
+
+/// A validated Unix timestamp — non-negative seconds since the Unix epoch.
+///
+/// Negative values (pre-1970) are rejected.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::temporal::UnixTimestamp;
+/// use arvo::traits::ValueObject;
+///
+/// let ts = UnixTimestamp::new(1_700_000_000).unwrap();
+/// assert_eq!(*ts.value(), 1_700_000_000);
+///
+/// assert!(UnixTimestamp::new(-1).is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct UnixTimestamp(i64);
+
+impl ValueObject for UnixTimestamp {
+    type Input = UnixTimestampInput;
+    type Output = UnixTimestampOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        if value < 0 {
+            return Err(ValidationError::invalid(
+                "UnixTimestamp",
+                &value.to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl std::fmt::Display for UnixTimestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_zero() {
+        let ts = UnixTimestamp::new(0).unwrap();
+        assert_eq!(*ts.value(), 0);
+    }
+
+    #[test]
+    fn accepts_positive() {
+        let ts = UnixTimestamp::new(1_700_000_000).unwrap();
+        assert_eq!(*ts.value(), 1_700_000_000);
+    }
+
+    #[test]
+    fn rejects_negative() {
+        assert!(UnixTimestamp::new(-1).is_err());
+    }
+
+    #[test]
+    fn into_inner_roundtrip() {
+        let ts = UnixTimestamp::new(42).unwrap();
+        assert_eq!(ts.into_inner(), 42);
+    }
+
+    #[test]
+    fn display() {
+        let ts = UnixTimestamp::new(1_000).unwrap();
+        assert_eq!(ts.to_string(), "1000");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `temporal` feature module with 5 validated value objects
- `UnixTimestamp` — non-negative `i64` seconds since the Unix epoch
- `BirthDate` — `NaiveDate` strictly in the past, max 150 years ago; `age_years()`
- `ExpiryDate` — `NaiveDate` strictly in the future; `days_until()`
- `TimeRange` — `DateTime<Utc>` start + end with `start < end`; `start()`, `end()`, `duration()`
- `BusinessHours` — weekday + `NaiveTime` open/close with `open < close`; output `"Mon 09:00–17:00"`; `duration()`
- Add `temporal = ["dep:chrono"]` feature to `Cargo.toml`
- Add `temporal` to `full` feature
- Add `docs/temporal.md` reference documentation
- Update `ROADMAP.md` and `README.md`

Closes #31
Closes #32
Closes #33
Closes #35
Closes #36

## Type of change

- [x] New value object / feature

## Checklist

- [x] `ValueObject` trait (`new` / `value` / `into_inner`)
- [x] `TryFrom<&str>` (not applicable — inputs are chrono types)
- [x] `Display`
- [x] `serde` `cfg_attr`
- [x] Tests (38 passing)
- [x] `cargo fmt` + clippy clean
- [x] `ROADMAP.md` updated
- [x] `README.md` updated
- [x] `docs/temporal.md` created