### PR TITLE
chore: release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arvo"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arvo"
-version = "0.5.0"
+version = "0.6.0"
 license = "MIT"
 description = "Validated, immutable value objects for common domain types (email, money, identifiers, …)"
 authors = ["Codegress <hello@codegress.com>"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ let email: EmailAddress = "user@example.com".try_into()?;
 
 ```toml
 [dependencies]
-arvo = { version = "0.5", features = ["contact", "serde"] }
+arvo = { version = "0.6", features = ["contact", "serde"] }
 ```
 
 Enable only the modules you need — unused features add zero dependencies.

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -4,7 +4,7 @@ Feature flag: `contact`
 
 ```toml
 [dependencies]
-arvo = { version = "0.5", features = ["contact"] }
+arvo = { version = "0.6", features = ["contact"] }
 ```
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! arvo = { version = "0.5", features = ["contact", "finance"] }
+//! arvo = { version = "0.6", features = ["contact", "finance"] }
 //! ```
 //!
 //! Available features: `contact`, `serde`, `full`.


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version from `0.5.0` → `0.6.0`
- Pin `chrono` to `"0.4.23"` (fixes minimal-versions CI — `date_naive()`, `from_ymd_opt()` etc. added in 0.4.23)
- Update version references in `README.md`, `src/lib.rs`, and all `docs/` pages
- `Cargo.lock` updated via `cargo check --all-features`

## Type of change

- [x] Chore / maintenance

## Checklist

- [x] Version bump is correct
- [x] `Cargo.lock` updated
- [x] All version references in docs updated to `0.6`
- [x] CI passes