### PR TITLE
chore: release 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arvo"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arvo"
-version = "0.6.0"
+version = "0.7.0"
 license = "MIT"
 description = "Validated, immutable value objects for common domain types (email, money, identifiers, …)"
 authors = ["Codegress <hello@codegress.com>"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ let email: EmailAddress = "user@example.com".try_into()?;
 
 ```toml
 [dependencies]
-arvo = { version = "0.6", features = ["contact", "serde"] }
+arvo = { version = "0.7", features = ["contact", "serde"] }
 ```
 
 Enable only the modules you need — unused features add zero dependencies.

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -4,7 +4,7 @@ Feature flag: `contact`
 
 ```toml
 [dependencies]
-arvo = { version = "0.6", features = ["contact"] }
+arvo = { version = "0.7", features = ["contact"] }
 ```
 
 ---

--- a/docs/finance.md
+++ b/docs/finance.md
@@ -4,7 +4,7 @@ Feature flag: `finance`
 
 ```toml
 [dependencies]
-arvo = { version = "0.5", features = ["finance"] }
+arvo = { version = "0.7", features = ["finance"] }
 ```
 
 ---

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -4,7 +4,7 @@ Feature flag: `identifiers`
 
 ```toml
 [dependencies]
-arvo = { version = "0.5", features = ["identifiers"] }
+arvo = { version = "0.7", features = ["identifiers"] }
 ```
 
 ---

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -4,7 +4,7 @@ Feature flag: `primitives`
 
 ```toml
 [dependencies]
-arvo = { version = "0.5", features = ["primitives"] }
+arvo = { version = "0.7", features = ["primitives"] }
 ```
 
 ---

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -4,7 +4,7 @@ Feature flag: `temporal`
 
 ```toml
 [dependencies]
-arvo = { version = "0.6", features = ["temporal"] }
+arvo = { version = "0.7", features = ["temporal"] }
 ```
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! arvo = { version = "0.6", features = ["contact", "finance"] }
+//! arvo = { version = "0.7", features = ["contact", "finance"] }
 //! ```
 //!
 //! Available features: `contact`, `serde`, `full`.


### PR DESCRIPTION
## Summary
- Bump version to 0.7.0 in Cargo.toml / Cargo.lock
- Update version references in README.md, docs/ and src/lib.rs

## Type of change
- [x] Release / version bump

## Checklist
- [x] cargo fmt + clippy clean
- [x] Version updated in Cargo.toml
- [x] Version references updated in all docs