### PR TITLE
Add net module (v0.8.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default = []
 contact = ["dep:once_cell", "dep:regex", "dep:url"]
 finance = ["dep:rust_decimal", "dep:chrono"]
 geo = []
+net = ["dep:url"]
 identifiers = []
 primitives = ["dep:rust_decimal", "dep:base64"]
 temporal = ["dep:chrono"]
@@ -35,6 +36,7 @@ full = [
     "finance",
     "geo",
     "identifiers",
+    "net",
     "primitives",
     "temporal",
 ]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ let email: EmailAddress = "user@example.com".try_into()?;
 | [docs/contact.md](docs/contact.md) | Reference for all `contact` module types |
 | [docs/finance.md](docs/finance.md) | Reference for all `finance` module types |
 | [docs/geo.md](docs/geo.md) | Reference for all `geo` module types |
+| [docs/net.md](docs/net.md) | Reference for all `net` module types |
 | [docs/identifiers.md](docs/identifiers.md) | Reference for all `identifiers` module types |
 | [docs/primitives.md](docs/primitives.md) | Reference for all `primitives` module types |
 | [docs/temporal.md](docs/temporal.md) | Reference for all `temporal` module types |
@@ -71,6 +72,7 @@ Enable only the modules you need — unused features add zero dependencies.
 | `contact` | `EmailAddress`, `CountryCode`, `PhoneNumber`, `PostalAddress`, `Website` | `once_cell`, `regex`, `url` |
 | `finance` | `Money`, `CurrencyCode`, `Iban`, `Bic`, `VatNumber`, `Percentage`, `ExchangeRate`, `CreditCardNumber`, `CardExpiryDate` | `rust_decimal`, `chrono` |
 | `geo` | `Latitude`, `Longitude`, `Coordinate`, `BoundingBox`, `TimeZone`, `CountryRegion` | — |
+| `net` | `Url`, `Domain`, `IpV4Address`, `IpV6Address`, `IpAddress`, `Port`, `MacAddress`, `MimeType`, `HttpStatusCode`, `ApiKey` | `url` |
 | `identifiers` | `Slug`, `Ean13`, `Ean8`, `Isbn13`, `Isbn10`, `Issn`, `Vin` | — |
 | `primitives` | `NonEmptyString`, `BoundedString`, `PositiveInt`, `NonNegativeInt`, `PositiveDecimal`, `NonNegativeDecimal`, `Probability`, `HexColor`, `Locale`, `Base64String` | `rust_decimal`, `base64` |
 | `temporal` | `UnixTimestamp`, `BirthDate`, `ExpiryDate`, `TimeRange`, `BusinessHours` | `chrono` |
@@ -210,7 +212,7 @@ let parsed: EmailAddress = serde_json::from_str(r#""hello@example.com""#)?;
 | `finance` | `Money`, `CurrencyCode`, `Iban`, `Bic`, `VatNumber`, `Percentage`, `ExchangeRate`, `CreditCardNumber`, `CardExpiryDate` | 9 | 9 / 9 ✅ |
 | `temporal` | `UnixTimestamp`, `BirthDate`, `ExpiryDate`, `TimeRange`, `BusinessHours` | 5 | 5 / 5 ✅ |
 | `geo` | `Latitude`, `Longitude`, `Coordinate`, `BoundingBox`, `TimeZone`, `CountryRegion` | 6 | 6 / 6 ✅ |
-| `net` | `Url`, `IpAddress`, `MacAddress`, `ApiKey`, `Port` | 10 | 0 / 10 |
+| `net` | `Url`, `Domain`, `IpV4Address`, `IpV6Address`, `IpAddress`, `Port`, `MacAddress`, `MimeType`, `HttpStatusCode`, `ApiKey` | 10 | 10 / 10 ✅ |
 | `measurement` | `Length`, `Weight`, `Temperature`, `Speed` ⚠️ needs unit conversion design | 10 | 0 / 10 |
 | `primitives` | `NonEmptyString`, `BoundedString`, `Locale`, `HexColor` | 10 | 10 / 10 ✅ |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,16 +81,16 @@
 
 | Type | Status | Notes |
 |---|---|---|
-| `Url` | ⬜ | valid URL, wraps `url` crate |
-| `Domain` | ⬜ | valid domain name without scheme |
-| `IpV4Address` | ⬜ | valid IPv4 (e.g. `192.168.1.1`) |
-| `IpV6Address` | ⬜ | valid IPv6 |
-| `IpAddress` | ⬜ | enum: `V4(IpV4Address)` \| `V6(IpV6Address)` |
-| `Port` | ⬜ | `u16` in range 1–65535 |
-| `MacAddress` | ⬜ | 6-byte MAC, normalised to lowercase colon-separated hex |
-| `MimeType` | ⬜ | valid MIME type (e.g. `image/png`) |
-| `HttpStatusCode` | ⬜ | `u16` in range 100–599 |
-| `ApiKey` | ⬜ | non-empty; masked `Display` shows only last 4 chars |
+| `Url` | ✅ | valid URL, wraps `url` crate |
+| `Domain` | ✅ | valid domain name without scheme |
+| `IpV4Address` | ✅ | valid IPv4 (e.g. `192.168.1.1`) |
+| `IpV6Address` | ✅ | valid IPv6 |
+| `IpAddress` | ✅ | enum: `V4(IpV4Address)` \| `V6(IpV6Address)` |
+| `Port` | ✅ | `u16` in range 1–65535 |
+| `MacAddress` | ✅ | 6-byte MAC, normalised to lowercase colon-separated hex |
+| `MimeType` | ✅ | valid MIME type (e.g. `image/png`) |
+| `HttpStatusCode` | ✅ | `u16` in range 100–599 |
+| `ApiKey` | ✅ | non-empty; masked `Display` shows only last 4 chars |
 
 ---
 
@@ -139,7 +139,7 @@
 | `finance` | 9 | 9 | 0 |
 | `temporal` | 5 | 5 | 0 |
 | `geo` | 6 | 6 | 0 |
-| `net` | 10 | 0 | 10 |
+| `net` | 10 | 10 | 0 |
 | `measurement` | 10 | 0 | 10 |
 | `primitives` | 10 | 10 | 0 |
-| **Total** | **62** | **42** | **20** |
+| **Total** | **62** | **52** | **10** |

--- a/docs/net.md
+++ b/docs/net.md
@@ -1,0 +1,330 @@
+# net module
+
+Feature flag: `net`
+
+```toml
+[dependencies]
+arvo = { version = "0.8", features = ["net"] }
+```
+
+---
+
+## Url
+
+A validated URL. Accepts `http`, `https`, `ftp`, `ftps`, `ws`, and `wss` schemes. Scheme and host are normalised to lowercase.
+
+**Validation:** must be a valid URL with an allowed scheme and a host.
+
+```rust,ignore
+use arvo::net::Url;
+use arvo::traits::ValueObject;
+
+let url = Url::new("HTTPS://Example.COM/path".into())?;
+assert_eq!(url.value(), "https://example.com/path");
+assert_eq!(url.scheme(), "https");
+assert_eq!(url.host(), "example.com");
+
+let url: Url = "https://example.com".try_into()?;
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"https://example.com/path"` |
+| `scheme()` | `&str` | `"https"` |
+| `host()` | `&str` | `"example.com"` |
+| `into_inner()` | `String` | `"https://example.com/path"` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `""` | `ValidationError::Empty` |
+| `"not-a-url"` | `ValidationError::InvalidFormat` |
+| `"mailto:user@example.com"` | `ValidationError::InvalidFormat` (scheme not allowed) |
+
+---
+
+## Domain
+
+A validated domain name without a scheme (e.g. `"example.com"`).
+
+**Normalisation:** trimmed, lowercased.
+**Validation:** at least two labels, each 1–63 alphanumeric/hyphen characters, not starting or ending with a hyphen.
+
+```rust,ignore
+use arvo::net::Domain;
+use arvo::traits::ValueObject;
+
+let domain = Domain::new("Example.COM".into())?;
+assert_eq!(domain.value(), "example.com");
+
+let domain: Domain = "api.example.com".try_into()?;
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"example.com"` |
+| `into_inner()` | `String` | `"example.com"` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `""` | `ValidationError::Empty` |
+| `"localhost"` | `ValidationError::InvalidFormat` (single label) |
+| `"-example.com"` | `ValidationError::InvalidFormat` (leading hyphen) |
+
+---
+
+## IpV4Address
+
+A validated IPv4 address. Leading zeros in octets are rejected.
+
+```rust,ignore
+use arvo::net::IpV4Address;
+use arvo::traits::ValueObject;
+
+let ip = IpV4Address::new("192.168.1.1".into())?;
+assert_eq!(ip.value(), "192.168.1.1");
+
+let ip: IpV4Address = "10.0.0.1".try_into()?;
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"192.168.1.1"` |
+| `into_inner()` | `String` | `"192.168.1.1"` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `""` | `ValidationError::Empty` |
+| `"256.0.0.1"` | `ValidationError::InvalidFormat` |
+| `"192.168.001.001"` | `ValidationError::InvalidFormat` (leading zeros) |
+
+---
+
+## IpV6Address
+
+A validated IPv6 address, normalised to canonical compressed lowercase form.
+
+```rust,ignore
+use arvo::net::IpV6Address;
+use arvo::traits::ValueObject;
+
+let ip = IpV6Address::new("2001:0db8::0001".into())?;
+assert_eq!(ip.value(), "2001:db8::1");
+
+let ip: IpV6Address = "::1".try_into()?;
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"2001:db8::1"` |
+| `into_inner()` | `String` | `"2001:db8::1"` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `""` | `ValidationError::Empty` |
+| `"not-an-ip"` | `ValidationError::InvalidFormat` |
+
+---
+
+## IpAddress
+
+A validated IP address — IPv4 or IPv6. Tries IPv4 first, then IPv6.
+
+```rust,ignore
+use arvo::net::IpAddress;
+use arvo::traits::ValueObject;
+
+let ip = IpAddress::new("192.168.1.1".into())?;
+assert!(ip.is_v4());
+
+let ip = IpAddress::new("::1".into())?;
+assert!(ip.is_v6());
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"192.168.1.1"` |
+| `is_v4()` | `bool` | `true` |
+| `is_v6()` | `bool` | `false` |
+| `into_inner()` | `String` | `"192.168.1.1"` |
+
+---
+
+## Port
+
+A validated network port number in the range `1..=65535`. Port 0 is reserved and rejected.
+
+```rust,ignore
+use arvo::net::Port;
+use arvo::traits::ValueObject;
+
+let port = Port::new(8080)?;
+assert_eq!(*port.value(), 8080);
+
+assert!(Port::new(0).is_err());
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&u16` | `8080` |
+| `into_inner()` | `u16` | `8080` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `0` | `ValidationError::InvalidFormat` |
+
+---
+
+## MacAddress
+
+A validated MAC address, normalised to lowercase colon-separated hex. Accepts colon-separated, hyphen-separated, or Cisco dotted formats.
+
+```rust,ignore
+use arvo::net::MacAddress;
+use arvo::traits::ValueObject;
+
+let mac = MacAddress::new("AA:BB:CC:DD:EE:FF".into())?;
+assert_eq!(mac.value(), "aa:bb:cc:dd:ee:ff");
+
+// Also accepts hyphen and dotted formats
+let mac = MacAddress::new("AA-BB-CC-DD-EE-FF".into())?;
+let mac = MacAddress::new("AABB.CCDD.EEFF".into())?;
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"aa:bb:cc:dd:ee:ff"` |
+| `into_inner()` | `String` | `"aa:bb:cc:dd:ee:ff"` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `""` | `ValidationError::Empty` |
+| `"AA:BB:CC:DD:EE"` | `ValidationError::InvalidFormat` (5 groups) |
+| `"GG:BB:CC:DD:EE:FF"` | `ValidationError::InvalidFormat` (invalid hex) |
+
+---
+
+## MimeType
+
+A validated MIME type. Trimmed and lowercased. Parameters (e.g. `; charset=utf-8`) are accepted and preserved.
+
+```rust,ignore
+use arvo::net::MimeType;
+use arvo::traits::ValueObject;
+
+let mime = MimeType::new("image/png".into())?;
+assert_eq!(mime.value(), "image/png");
+assert_eq!(mime.type_part(), "image");
+assert_eq!(mime.subtype(), "png");
+
+let mime = MimeType::new("text/html; charset=utf-8".into())?;
+assert_eq!(mime.subtype(), "html");
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"image/png"` |
+| `type_part()` | `&str` | `"image"` |
+| `subtype()` | `&str` | `"png"` |
+| `into_inner()` | `String` | `"image/png"` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `""` | `ValidationError::Empty` |
+| `"imagepng"` | `ValidationError::InvalidFormat` (no slash) |
+| `"image/"` | `ValidationError::InvalidFormat` (empty subtype) |
+
+---
+
+## HttpStatusCode
+
+A validated HTTP status code in the range `100..=599`.
+
+```rust,ignore
+use arvo::net::HttpStatusCode;
+use arvo::traits::ValueObject;
+
+let code = HttpStatusCode::new(200)?;
+assert!(code.is_success());
+
+let code = HttpStatusCode::new(404)?;
+assert!(code.is_client_error());
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&u16` | `200` |
+| `is_informational()` | `bool` | `false` |
+| `is_success()` | `bool` | `true` |
+| `is_redirection()` | `bool` | `false` |
+| `is_client_error()` | `bool` | `false` |
+| `is_server_error()` | `bool` | `false` |
+| `into_inner()` | `u16` | `200` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `< 100` or `> 599` | `ValidationError::InvalidFormat` |
+
+---
+
+## ApiKey
+
+A validated API key — non-empty string. `Display` shows a masked form with only the last 4 characters visible.
+
+```rust,ignore
+use arvo::net::ApiKey;
+use arvo::traits::ValueObject;
+
+let key = ApiKey::new("sk-1234567890abcd".into())?;
+assert_eq!(key.value(), "sk-1234567890abcd");  // full key
+assert_eq!(key.last_four(), "abcd");
+println!("{key}");  // *************abcd
+```
+
+### Accessors
+
+| Method | Returns | Example |
+|---|---|---|
+| `value()` | `&String` | `"sk-1234567890abcd"` (full) |
+| `last_four()` | `&str` | `"abcd"` |
+| `masked()` | `String` | `"*************abcd"` |
+| `into_inner()` | `String` | `"sk-1234567890abcd"` |
+
+### Errors
+
+| Input | Error |
+|---|---|
+| `""` or whitespace only | `ValidationError::Empty` |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ pub mod finance;
 #[cfg(feature = "geo")]
 pub mod geo;
 
+#[cfg(feature = "net")]
+pub mod net;
+
 #[cfg(feature = "identifiers")]
 pub mod identifiers;
 

--- a/src/net/api_key.rs
+++ b/src/net/api_key.rs
@@ -1,0 +1,132 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`ApiKey`].
+pub type ApiKeyInput = String;
+
+/// Output type for [`ApiKey`].
+pub type ApiKeyOutput = String;
+
+/// A validated API key — non-empty, trimmed.
+///
+/// `Display` shows a masked version with only the last 4 characters visible
+/// (e.g. `"****abcd"`). `value()` returns the full key.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::ApiKey;
+/// use arvo::traits::ValueObject;
+///
+/// let key = ApiKey::new("sk-1234567890abcd".into())?;
+/// assert_eq!(key.value(), "sk-1234567890abcd");
+/// assert_eq!(key.to_string(), "************abcd");
+/// assert_eq!(key.last_four(), "abcd");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct ApiKey(String);
+
+impl ValueObject for ApiKey {
+    type Input = ApiKeyInput;
+    type Output = ApiKeyOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let trimmed = value.trim().to_owned();
+
+        if trimmed.is_empty() {
+            return Err(ValidationError::empty("ApiKey"));
+        }
+
+        Ok(Self(trimmed))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl ApiKey {
+    /// Returns the last 4 characters of the key.
+    pub fn last_four(&self) -> &str {
+        let len = self.0.len();
+        if len <= 4 {
+            &self.0
+        } else {
+            &self.0[len - 4..]
+        }
+    }
+
+    /// Returns the masked representation: `****` prefix + last 4 chars.
+    pub fn masked(&self) -> String {
+        let len = self.0.len();
+        let mask_len = len.saturating_sub(4);
+        format!("{}{}", "*".repeat(mask_len), self.last_four())
+    }
+}
+
+impl std::fmt::Display for ApiKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.masked())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_key() {
+        let key = ApiKey::new("sk-1234567890abcd".into()).unwrap();
+        assert_eq!(key.value(), "sk-1234567890abcd");
+    }
+
+    #[test]
+    fn trims_whitespace() {
+        let key = ApiKey::new("  mykey  ".into()).unwrap();
+        assert_eq!(key.value(), "mykey");
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(ApiKey::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_whitespace_only() {
+        assert!(ApiKey::new("   ".into()).is_err());
+    }
+
+    #[test]
+    fn last_four() {
+        let key = ApiKey::new("sk-1234567890abcd".into()).unwrap();
+        assert_eq!(key.last_four(), "abcd");
+    }
+
+    #[test]
+    fn last_four_short_key() {
+        let key = ApiKey::new("abc".into()).unwrap();
+        assert_eq!(key.last_four(), "abc");
+    }
+
+    #[test]
+    fn masked_display() {
+        let key = ApiKey::new("sk-1234567890abcd".into()).unwrap();
+        // "sk-1234567890abcd" is 18 chars, last 4 = "abcd", masked = 14 stars + "abcd"
+        assert_eq!(key.to_string(), "*************abcd");
+    }
+
+    #[test]
+    fn display_masks_key() {
+        let key = ApiKey::new("secret".into()).unwrap();
+        let displayed = key.to_string();
+        assert!(displayed.ends_with("cret"));
+        assert!(displayed.starts_with("**"));
+    }
+}

--- a/src/net/domain.rs
+++ b/src/net/domain.rs
@@ -1,0 +1,157 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`Domain`].
+pub type DomainInput = String;
+
+/// Output type for [`Domain`].
+pub type DomainOutput = String;
+
+/// A validated domain name without a scheme (e.g. `"example.com"`).
+///
+/// **Normalisation:** trimmed, lowercased.
+/// **Validation:** labels separated by `.`, each label 1–63 ASCII alphanumeric
+/// or hyphen characters, not starting or ending with a hyphen, total length
+/// ≤ 253 characters, at least two labels.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::Domain;
+/// use arvo::traits::ValueObject;
+///
+/// let domain = Domain::new("Example.COM".into())?;
+/// assert_eq!(domain.value(), "example.com");
+///
+/// let domain: Domain = "api.example.com".try_into()?;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Domain(String);
+
+impl ValueObject for Domain {
+    type Input = DomainInput;
+    type Output = DomainOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let normalised = value.trim().to_lowercase();
+
+        if normalised.is_empty() {
+            return Err(ValidationError::empty("Domain"));
+        }
+
+        if !is_valid_domain(&normalised) {
+            return Err(ValidationError::invalid("Domain", &normalised));
+        }
+
+        Ok(Self(normalised))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+fn is_valid_domain(s: &str) -> bool {
+    if s.len() > 253 {
+        return false;
+    }
+
+    let labels: Vec<&str> = s.split('.').collect();
+
+    if labels.len() < 2 {
+        return false;
+    }
+
+    for label in &labels {
+        if label.is_empty() || label.len() > 63 {
+            return false;
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return false;
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return false;
+        }
+    }
+
+    true
+}
+
+impl TryFrom<&str> for Domain {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for Domain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_simple_domain() {
+        let d = Domain::new("example.com".into()).unwrap();
+        assert_eq!(d.value(), "example.com");
+    }
+
+    #[test]
+    fn normalises_to_lowercase() {
+        let d = Domain::new("Example.COM".into()).unwrap();
+        assert_eq!(d.value(), "example.com");
+    }
+
+    #[test]
+    fn accepts_subdomain() {
+        assert!(Domain::new("api.example.com".into()).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(Domain::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_single_label() {
+        assert!(Domain::new("localhost".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_leading_hyphen_in_label() {
+        assert!(Domain::new("-example.com".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_hyphen_in_label() {
+        assert!(Domain::new("example-.com".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_label() {
+        assert!(Domain::new("example..com".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_url_with_scheme() {
+        assert!(Domain::new("https://example.com".into()).is_err());
+    }
+
+    #[test]
+    fn try_from_str() {
+        let d: Domain = "example.org".try_into().unwrap();
+        assert_eq!(d.value(), "example.org");
+    }
+}

--- a/src/net/http_status_code.rs
+++ b/src/net/http_status_code.rs
@@ -1,0 +1,132 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`HttpStatusCode`].
+pub type HttpStatusCodeInput = u16;
+
+/// Output type for [`HttpStatusCode`].
+pub type HttpStatusCodeOutput = u16;
+
+/// A validated HTTP status code in the range `100..=599`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::HttpStatusCode;
+/// use arvo::traits::ValueObject;
+///
+/// let code = HttpStatusCode::new(200)?;
+/// assert_eq!(*code.value(), 200);
+/// assert!(code.is_success());
+///
+/// assert!(HttpStatusCode::new(600).is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct HttpStatusCode(u16);
+
+impl ValueObject for HttpStatusCode {
+    type Input = HttpStatusCodeInput;
+    type Output = HttpStatusCodeOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        if !(100..=599).contains(&value) {
+            return Err(ValidationError::invalid(
+                "HttpStatusCode",
+                &value.to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl HttpStatusCode {
+    /// Returns `true` for 1xx informational codes.
+    pub fn is_informational(&self) -> bool {
+        (100..=199).contains(&self.0)
+    }
+
+    /// Returns `true` for 2xx success codes.
+    pub fn is_success(&self) -> bool {
+        (200..=299).contains(&self.0)
+    }
+
+    /// Returns `true` for 3xx redirection codes.
+    pub fn is_redirection(&self) -> bool {
+        (300..=399).contains(&self.0)
+    }
+
+    /// Returns `true` for 4xx client error codes.
+    pub fn is_client_error(&self) -> bool {
+        (400..=499).contains(&self.0)
+    }
+
+    /// Returns `true` for 5xx server error codes.
+    pub fn is_server_error(&self) -> bool {
+        (500..=599).contains(&self.0)
+    }
+}
+
+impl std::fmt::Display for HttpStatusCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_200() {
+        let code = HttpStatusCode::new(200).unwrap();
+        assert_eq!(*code.value(), 200);
+    }
+
+    #[test]
+    fn accepts_boundaries() {
+        assert!(HttpStatusCode::new(100).is_ok());
+        assert!(HttpStatusCode::new(599).is_ok());
+    }
+
+    #[test]
+    fn rejects_below_100() {
+        assert!(HttpStatusCode::new(99).is_err());
+    }
+
+    #[test]
+    fn rejects_600_and_above() {
+        assert!(HttpStatusCode::new(600).is_err());
+    }
+
+    #[test]
+    fn category_helpers() {
+        assert!(HttpStatusCode::new(100).unwrap().is_informational());
+        assert!(HttpStatusCode::new(200).unwrap().is_success());
+        assert!(HttpStatusCode::new(301).unwrap().is_redirection());
+        assert!(HttpStatusCode::new(404).unwrap().is_client_error());
+        assert!(HttpStatusCode::new(500).unwrap().is_server_error());
+    }
+
+    #[test]
+    fn display() {
+        let code = HttpStatusCode::new(404).unwrap();
+        assert_eq!(code.to_string(), "404");
+    }
+
+    #[test]
+    fn into_inner_roundtrip() {
+        let code = HttpStatusCode::new(201).unwrap();
+        assert_eq!(code.into_inner(), 201);
+    }
+}

--- a/src/net/ip_address.rs
+++ b/src/net/ip_address.rs
@@ -1,0 +1,134 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+use super::{IpV4Address, IpV6Address};
+
+/// Input for [`IpAddress`] — either a v4 or v6 address string.
+pub type IpAddressInput = String;
+
+/// Output type for [`IpAddress`].
+pub type IpAddressOutput = String;
+
+/// A validated IP address — either IPv4 or IPv6.
+///
+/// Tries IPv4 first, then IPv6. The canonical string is stored normalised.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::IpAddress;
+/// use arvo::traits::ValueObject;
+///
+/// let ip = IpAddress::new("192.168.1.1".into())?;
+/// assert!(ip.is_v4());
+///
+/// let ip = IpAddress::new("::1".into())?;
+/// assert!(ip.is_v6());
+///
+/// let ip: IpAddress = "10.0.0.1".try_into()?;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct IpAddress(String);
+
+impl ValueObject for IpAddress {
+    type Input = IpAddressInput;
+    type Output = IpAddressOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let trimmed = value.trim();
+
+        if trimmed.is_empty() {
+            return Err(ValidationError::empty("IpAddress"));
+        }
+
+        if let Ok(v4) = IpV4Address::new(trimmed.to_owned()) {
+            return Ok(Self(v4.into_inner()));
+        }
+
+        if let Ok(v6) = IpV6Address::new(trimmed.to_owned()) {
+            return Ok(Self(v6.into_inner()));
+        }
+
+        Err(ValidationError::invalid("IpAddress", trimmed))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl IpAddress {
+    /// Returns `true` if the address is IPv4.
+    pub fn is_v4(&self) -> bool {
+        self.0.contains('.')
+    }
+
+    /// Returns `true` if the address is IPv6.
+    pub fn is_v6(&self) -> bool {
+        self.0.contains(':')
+    }
+}
+
+impl TryFrom<&str> for IpAddress {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for IpAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_ipv4() {
+        let ip = IpAddress::new("192.168.1.1".into()).unwrap();
+        assert_eq!(ip.value(), "192.168.1.1");
+        assert!(ip.is_v4());
+        assert!(!ip.is_v6());
+    }
+
+    #[test]
+    fn accepts_ipv6() {
+        let ip = IpAddress::new("::1".into()).unwrap();
+        assert_eq!(ip.value(), "::1");
+        assert!(ip.is_v6());
+        assert!(!ip.is_v4());
+    }
+
+    #[test]
+    fn normalises_ipv6() {
+        let ip = IpAddress::new("2001:0db8::0001".into()).unwrap();
+        assert_eq!(ip.value(), "2001:db8::1");
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(IpAddress::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid() {
+        assert!(IpAddress::new("not-an-ip".into()).is_err());
+    }
+
+    #[test]
+    fn try_from_str() {
+        let ip: IpAddress = "10.0.0.1".try_into().unwrap();
+        assert!(ip.is_v4());
+    }
+}

--- a/src/net/ip_v4_address.rs
+++ b/src/net/ip_v4_address.rs
@@ -1,0 +1,135 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+use std::net::Ipv4Addr;
+
+/// Input type for [`IpV4Address`].
+pub type IpV4AddressInput = String;
+
+/// Output type for [`IpV4Address`].
+pub type IpV4AddressOutput = String;
+
+/// A validated IPv4 address (e.g. `"192.168.1.1"`).
+///
+/// **Normalisation:** trimmed. Leading zeros in octets are rejected
+/// (e.g. `"192.168.001.001"` is invalid).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::IpV4Address;
+/// use arvo::traits::ValueObject;
+///
+/// let ip = IpV4Address::new("192.168.1.1".into())?;
+/// assert_eq!(ip.value(), "192.168.1.1");
+///
+/// let ip: IpV4Address = "10.0.0.1".try_into()?;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct IpV4Address(String);
+
+impl ValueObject for IpV4Address {
+    type Input = IpV4AddressInput;
+    type Output = IpV4AddressOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let trimmed = value.trim();
+
+        if trimmed.is_empty() {
+            return Err(ValidationError::empty("IpV4Address"));
+        }
+
+        // Reject leading zeros in any octet
+        for octet in trimmed.split('.') {
+            if octet.len() > 1 && octet.starts_with('0') {
+                return Err(ValidationError::invalid("IpV4Address", trimmed));
+            }
+        }
+
+        trimmed
+            .parse::<Ipv4Addr>()
+            .map(|ip| Self(ip.to_string()))
+            .map_err(|_| ValidationError::invalid("IpV4Address", trimmed))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for IpV4Address {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for IpV4Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_ipv4() {
+        let ip = IpV4Address::new("192.168.1.1".into()).unwrap();
+        assert_eq!(ip.value(), "192.168.1.1");
+    }
+
+    #[test]
+    fn accepts_loopback() {
+        assert!(IpV4Address::new("127.0.0.1".into()).is_ok());
+    }
+
+    #[test]
+    fn accepts_all_zeros() {
+        assert!(IpV4Address::new("0.0.0.0".into()).is_ok());
+    }
+
+    #[test]
+    fn accepts_broadcast() {
+        assert!(IpV4Address::new("255.255.255.255".into()).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(IpV4Address::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_octet() {
+        assert!(IpV4Address::new("256.0.0.1".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_too_few_octets() {
+        assert!(IpV4Address::new("192.168.1".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_leading_zeros() {
+        assert!(IpV4Address::new("192.168.001.001".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_ipv6() {
+        assert!(IpV4Address::new("::1".into()).is_err());
+    }
+
+    #[test]
+    fn try_from_str() {
+        let ip: IpV4Address = "10.0.0.1".try_into().unwrap();
+        assert_eq!(ip.value(), "10.0.0.1");
+    }
+}

--- a/src/net/ip_v6_address.rs
+++ b/src/net/ip_v6_address.rs
@@ -1,0 +1,115 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+use std::net::Ipv6Addr;
+
+/// Input type for [`IpV6Address`].
+pub type IpV6AddressInput = String;
+
+/// Output type for [`IpV6Address`].
+pub type IpV6AddressOutput = String;
+
+/// A validated IPv6 address (e.g. `"2001:db8::1"`).
+///
+/// **Normalisation:** trimmed; the address is stored in the canonical
+/// compressed lowercase form produced by Rust's standard library
+/// (e.g. `"2001:0db8:0000:0000:0000:0000:0000:0001"` → `"2001:db8::1"`).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::IpV6Address;
+/// use arvo::traits::ValueObject;
+///
+/// let ip = IpV6Address::new("2001:0db8::0001".into())?;
+/// assert_eq!(ip.value(), "2001:db8::1");
+///
+/// let ip: IpV6Address = "::1".try_into()?;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct IpV6Address(String);
+
+impl ValueObject for IpV6Address {
+    type Input = IpV6AddressInput;
+    type Output = IpV6AddressOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let trimmed = value.trim();
+
+        if trimmed.is_empty() {
+            return Err(ValidationError::empty("IpV6Address"));
+        }
+
+        trimmed
+            .parse::<Ipv6Addr>()
+            .map(|ip| Self(ip.to_string()))
+            .map_err(|_| ValidationError::invalid("IpV6Address", trimmed))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for IpV6Address {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for IpV6Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_loopback() {
+        let ip = IpV6Address::new("::1".into()).unwrap();
+        assert_eq!(ip.value(), "::1");
+    }
+
+    #[test]
+    fn normalises_to_compressed_form() {
+        let ip = IpV6Address::new("2001:0db8:0000:0000:0000:0000:0000:0001".into()).unwrap();
+        assert_eq!(ip.value(), "2001:db8::1");
+    }
+
+    #[test]
+    fn accepts_full_address() {
+        assert!(IpV6Address::new("2001:db8:85a3::8a2e:370:7334".into()).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(IpV6Address::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_ipv4() {
+        assert!(IpV6Address::new("192.168.1.1".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid() {
+        assert!(IpV6Address::new("not-an-ip".into()).is_err());
+    }
+
+    #[test]
+    fn try_from_str() {
+        let ip: IpV6Address = "::1".try_into().unwrap();
+        assert_eq!(ip.value(), "::1");
+    }
+}

--- a/src/net/mac_address.rs
+++ b/src/net/mac_address.rs
@@ -1,0 +1,171 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`MacAddress`].
+pub type MacAddressInput = String;
+
+/// Output type for [`MacAddress`].
+pub type MacAddressOutput = String;
+
+/// A validated MAC address, normalised to lowercase colon-separated hex.
+///
+/// **Normalisation:** accepts colon-separated (`AA:BB:CC:DD:EE:FF`),
+/// hyphen-separated (`AA-BB-CC-DD-EE-FF`), or dotted (`AABB.CCDD.EEFF`) formats.
+/// Stored as lowercase colon-separated (e.g. `"aa:bb:cc:dd:ee:ff"`).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::MacAddress;
+/// use arvo::traits::ValueObject;
+///
+/// let mac = MacAddress::new("AA:BB:CC:DD:EE:FF".into())?;
+/// assert_eq!(mac.value(), "aa:bb:cc:dd:ee:ff");
+///
+/// let mac: MacAddress = "AA-BB-CC-DD-EE-FF".try_into()?;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct MacAddress(String);
+
+impl ValueObject for MacAddress {
+    type Input = MacAddressInput;
+    type Output = MacAddressOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let trimmed = value.trim();
+
+        if trimmed.is_empty() {
+            return Err(ValidationError::empty("MacAddress"));
+        }
+
+        let bytes = parse_mac_bytes(trimmed)
+            .ok_or_else(|| ValidationError::invalid("MacAddress", trimmed))?;
+
+        let canonical = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5]
+        );
+
+        Ok(Self(canonical))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+fn parse_mac_bytes(s: &str) -> Option<[u8; 6]> {
+    // colon or hyphen separated: XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX
+    let sep = if s.contains(':') {
+        Some(':')
+    } else if s.contains('-') {
+        Some('-')
+    } else {
+        None
+    };
+
+    if let Some(sep) = sep {
+        let parts: Vec<&str> = s.split(sep).collect();
+        if parts.len() != 6 {
+            return None;
+        }
+        let mut bytes = [0u8; 6];
+        for (i, part) in parts.iter().enumerate() {
+            if part.len() != 2 {
+                return None;
+            }
+            bytes[i] = u8::from_str_radix(part, 16).ok()?;
+        }
+        return Some(bytes);
+    }
+
+    // Cisco dotted: XXXX.XXXX.XXXX
+    if s.contains('.') {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return None;
+        }
+        let hex: String = parts.concat();
+        if hex.len() != 12 {
+            return None;
+        }
+        let mut bytes = [0u8; 6];
+        for i in 0..6 {
+            bytes[i] = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
+        }
+        return Some(bytes);
+    }
+
+    None
+}
+
+impl TryFrom<&str> for MacAddress {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for MacAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_colon_separated() {
+        let mac = MacAddress::new("AA:BB:CC:DD:EE:FF".into()).unwrap();
+        assert_eq!(mac.value(), "aa:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn accepts_hyphen_separated() {
+        let mac = MacAddress::new("AA-BB-CC-DD-EE-FF".into()).unwrap();
+        assert_eq!(mac.value(), "aa:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn accepts_dotted_format() {
+        let mac = MacAddress::new("AABB.CCDD.EEFF".into()).unwrap();
+        assert_eq!(mac.value(), "aa:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn normalises_to_lowercase() {
+        let mac = MacAddress::new("AA:BB:CC:DD:EE:FF".into()).unwrap();
+        assert_eq!(mac.value(), "aa:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(MacAddress::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_too_few_groups() {
+        assert!(MacAddress::new("AA:BB:CC:DD:EE".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_hex() {
+        assert!(MacAddress::new("GG:BB:CC:DD:EE:FF".into()).is_err());
+    }
+
+    #[test]
+    fn try_from_str() {
+        let mac: MacAddress = "aa:bb:cc:dd:ee:ff".try_into().unwrap();
+        assert_eq!(mac.value(), "aa:bb:cc:dd:ee:ff");
+    }
+}

--- a/src/net/mime_type.rs
+++ b/src/net/mime_type.rs
@@ -1,0 +1,169 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`MimeType`].
+pub type MimeTypeInput = String;
+
+/// Output type for [`MimeType`].
+pub type MimeTypeOutput = String;
+
+/// A validated MIME type (e.g. `"image/png"`, `"application/json"`).
+///
+/// **Normalisation:** trimmed, lowercased.
+/// **Validation:** `type/subtype` format; type and subtype consist of
+/// ASCII alphanumeric characters, hyphens, dots, or plus signs.
+/// Parameters (e.g. `; charset=utf-8`) are accepted and preserved.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::MimeType;
+/// use arvo::traits::ValueObject;
+///
+/// let mime = MimeType::new("image/png".into())?;
+/// assert_eq!(mime.value(), "image/png");
+/// assert_eq!(mime.type_part(), "image");
+/// assert_eq!(mime.subtype(), "png");
+///
+/// let mime: MimeType = "application/json".try_into()?;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct MimeType(String);
+
+impl ValueObject for MimeType {
+    type Input = MimeTypeInput;
+    type Output = MimeTypeOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let normalised = value.trim().to_lowercase();
+
+        if normalised.is_empty() {
+            return Err(ValidationError::empty("MimeType"));
+        }
+
+        if !is_valid_mime(&normalised) {
+            return Err(ValidationError::invalid("MimeType", &normalised));
+        }
+
+        Ok(Self(normalised))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+fn is_valid_mime(s: &str) -> bool {
+    // Split off optional parameters (; charset=utf-8)
+    let base = s.split(';').next().unwrap_or("").trim();
+
+    let Some(slash) = base.find('/') else {
+        return false;
+    };
+
+    let type_part = &base[..slash];
+    let subtype = &base[slash + 1..];
+
+    if type_part.is_empty() || subtype.is_empty() {
+        return false;
+    }
+
+    let is_token_char = |c: char| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '+' | '_');
+
+    type_part.chars().all(is_token_char) && subtype.chars().all(is_token_char)
+}
+
+impl MimeType {
+    /// Returns the type part, e.g. `"image"`.
+    pub fn type_part(&self) -> &str {
+        self.0.split('/').next().unwrap_or("")
+    }
+
+    /// Returns the subtype part, e.g. `"png"` (without parameters).
+    pub fn subtype(&self) -> &str {
+        let after_slash = self.0.split('/').nth(1).unwrap_or("");
+        after_slash.split(';').next().unwrap_or("").trim()
+    }
+}
+
+impl TryFrom<&str> for MimeType {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for MimeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_image_png() {
+        let m = MimeType::new("image/png".into()).unwrap();
+        assert_eq!(m.value(), "image/png");
+    }
+
+    #[test]
+    fn normalises_to_lowercase() {
+        let m = MimeType::new("Application/JSON".into()).unwrap();
+        assert_eq!(m.value(), "application/json");
+    }
+
+    #[test]
+    fn accepts_with_parameter() {
+        assert!(MimeType::new("text/html; charset=utf-8".into()).is_ok());
+    }
+
+    #[test]
+    fn accepts_vendor_type() {
+        assert!(MimeType::new("application/vnd.api+json".into()).is_ok());
+    }
+
+    #[test]
+    fn type_part_and_subtype() {
+        let m = MimeType::new("image/png".into()).unwrap();
+        assert_eq!(m.type_part(), "image");
+        assert_eq!(m.subtype(), "png");
+    }
+
+    #[test]
+    fn subtype_without_parameter() {
+        let m = MimeType::new("text/html; charset=utf-8".into()).unwrap();
+        assert_eq!(m.subtype(), "html");
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(MimeType::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_slash() {
+        assert!(MimeType::new("imagepng".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_subtype() {
+        assert!(MimeType::new("image/".into()).is_err());
+    }
+
+    #[test]
+    fn try_from_str() {
+        let m: MimeType = "text/plain".try_into().unwrap();
+        assert_eq!(m.value(), "text/plain");
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,21 @@
+mod api_key;
+mod domain;
+mod http_status_code;
+mod ip_address;
+mod ip_v4_address;
+mod ip_v6_address;
+mod mac_address;
+mod mime_type;
+mod port;
+mod url;
+
+pub use api_key::ApiKey;
+pub use domain::Domain;
+pub use http_status_code::HttpStatusCode;
+pub use ip_address::IpAddress;
+pub use ip_v4_address::IpV4Address;
+pub use ip_v6_address::IpV6Address;
+pub use mac_address::MacAddress;
+pub use mime_type::MimeType;
+pub use port::Port;
+pub use url::Url;

--- a/src/net/port.rs
+++ b/src/net/port.rs
@@ -1,0 +1,100 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`Port`].
+pub type PortInput = u16;
+
+/// Output type for [`Port`].
+pub type PortOutput = u16;
+
+/// A validated network port number in the range `1..=65535`.
+///
+/// Port 0 is reserved and rejected.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::Port;
+/// use arvo::traits::ValueObject;
+///
+/// let port = Port::new(8080)?;
+/// assert_eq!(*port.value(), 8080);
+///
+/// assert!(Port::new(0).is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Port(u16);
+
+impl ValueObject for Port {
+    type Input = PortInput;
+    type Output = PortOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        if value == 0 {
+            return Err(ValidationError::invalid("Port", &value.to_string()));
+        }
+        Ok(Self(value))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl std::fmt::Display for Port {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_port() {
+        let port = Port::new(8080).unwrap();
+        assert_eq!(*port.value(), 8080);
+    }
+
+    #[test]
+    fn accepts_port_1() {
+        assert!(Port::new(1).is_ok());
+    }
+
+    #[test]
+    fn accepts_port_65535() {
+        assert!(Port::new(65535).is_ok());
+    }
+
+    #[test]
+    fn accepts_well_known_ports() {
+        assert!(Port::new(80).is_ok());
+        assert!(Port::new(443).is_ok());
+        assert!(Port::new(22).is_ok());
+    }
+
+    #[test]
+    fn rejects_zero() {
+        assert!(Port::new(0).is_err());
+    }
+
+    #[test]
+    fn display() {
+        let port = Port::new(443).unwrap();
+        assert_eq!(port.to_string(), "443");
+    }
+
+    #[test]
+    fn into_inner_roundtrip() {
+        let port = Port::new(3000).unwrap();
+        assert_eq!(port.into_inner(), 3000);
+    }
+}

--- a/src/net/url.rs
+++ b/src/net/url.rs
@@ -1,0 +1,162 @@
+use crate::errors::ValidationError;
+use crate::traits::ValueObject;
+
+/// Input type for [`Url`].
+pub type UrlInput = String;
+
+/// Output type for [`Url`].
+pub type UrlOutput = String;
+
+/// A validated URL. Accepts `http`, `https`, `ftp`, `ftps`, `ws`, and `wss` schemes.
+/// Scheme and host are normalised to lowercase on construction.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arvo::net::Url;
+/// use arvo::traits::ValueObject;
+///
+/// let url = Url::new("HTTPS://Example.COM/path".into())?;
+/// assert_eq!(url.value(), "https://example.com/path");
+/// assert_eq!(url.scheme(), "https");
+/// assert_eq!(url.host(), "example.com");
+///
+/// let url: Url = "https://example.com".try_into()?;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Url(String);
+
+const ALLOWED_SCHEMES: &[&str] = &["ftp", "ftps", "http", "https", "ws", "wss"];
+
+impl ValueObject for Url {
+    type Input = UrlInput;
+    type Output = UrlOutput;
+    type Error = ValidationError;
+
+    fn new(value: Self::Input) -> Result<Self, Self::Error> {
+        let trimmed = value.trim();
+
+        if trimmed.is_empty() {
+            return Err(ValidationError::empty("Url"));
+        }
+
+        let parsed =
+            ::url::Url::parse(trimmed).map_err(|_| ValidationError::invalid("Url", trimmed))?;
+
+        if parsed.host_str().is_none() {
+            return Err(ValidationError::invalid("Url", trimmed));
+        }
+
+        let scheme = parsed.scheme();
+        if ALLOWED_SCHEMES.binary_search(&scheme).is_err() {
+            return Err(ValidationError::invalid("Url", trimmed));
+        }
+
+        let canonical = parsed.to_string();
+
+        Ok(Self(canonical))
+    }
+
+    fn value(&self) -> &Self::Output {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::Input {
+        self.0
+    }
+}
+
+impl Url {
+    /// Returns the scheme, e.g. `"https"`.
+    pub fn scheme(&self) -> &str {
+        self.0.split("://").next().unwrap_or("")
+    }
+
+    /// Returns the host, e.g. `"example.com"`.
+    pub fn host(&self) -> &str {
+        let after_scheme = self.0.split("://").nth(1).unwrap_or("");
+        after_scheme
+            .split('/')
+            .next()
+            .unwrap_or("")
+            .split('?')
+            .next()
+            .unwrap_or("")
+    }
+}
+
+impl TryFrom<&str> for Url {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl std::fmt::Display for Url {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_https_url() {
+        let url = Url::new("https://example.com/path".into()).unwrap();
+        assert_eq!(url.value(), "https://example.com/path");
+    }
+
+    #[test]
+    fn normalises_scheme_and_host() {
+        let url = Url::new("HTTPS://EXAMPLE.COM/path".into()).unwrap();
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host(), "example.com");
+    }
+
+    #[test]
+    fn accepts_http() {
+        assert!(Url::new("http://example.com".into()).is_ok());
+    }
+
+    #[test]
+    fn accepts_ftp() {
+        assert!(Url::new("ftp://files.example.com/file.txt".into()).is_ok());
+    }
+
+    #[test]
+    fn accepts_ws() {
+        assert!(Url::new("ws://example.com/socket".into()).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(Url::new(String::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_url() {
+        assert!(Url::new("not-a-url".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_disallowed_scheme() {
+        assert!(Url::new("mailto:user@example.com".into()).is_err());
+        assert!(Url::new("file:///etc/passwd".into()).is_err());
+    }
+
+    #[test]
+    fn rejects_no_host() {
+        assert!(Url::new("https://".into()).is_err());
+    }
+
+    #[test]
+    fn try_from_str() {
+        let url: Url = "https://example.com".try_into().unwrap();
+        assert_eq!(url.scheme(), "https");
+    }
+}


### PR DESCRIPTION
## Summary
- `Url` — validated URL (http/https/ftp/ftps/ws/wss), scheme+host normalised to lowercase
- `Domain` — domain without scheme, lowercased, at least two labels
- `IpV4Address` — IPv4, rejects leading zeros in octets
- `IpV6Address` — IPv6, normalised to canonical compressed lowercase form
- `IpAddress` — IPv4 or IPv6, tries v4 first
- `Port` — `u16` in range 1–65535
- `MacAddress` — accepts colon/hyphen/dotted formats, stored as lowercase colon-separated
- `MimeType` — `type/subtype`, lowercased, parameters accepted
- `HttpStatusCode` — `u16` in range 100–599, with `is_success()` etc. helpers
- `ApiKey` — non-empty; `Display` masks all but last 4 chars

Extra dep: `url` (already used by `contact`).

Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54
Closes #55

## Type of change
- [x] New value object / feature

## Checklist
- [x] ValueObject trait (new / value / into_inner)
- [x] TryFrom<&str> where applicable
- [x] Display
- [x] serde cfg_attr
- [x] Tests (83 passing)
- [x] cargo fmt + clippy clean
- [x] ROADMAP.md updated
- [x] README.md updated
- [x] docs/net.md added