### PR TITLE
chore: release 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arvo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arvo"
-version = "0.8.0"
+version = "0.9.0"
 license = "MIT"
 description = "Validated, immutable value objects for common domain types (email, money, identifiers, …)"
 authors = ["Codegress <hello@codegress.com>"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let email: EmailAddress = "user@example.com".try_into()?;
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["contact", "serde"] }
+arvo = { version = "0.9", features = ["contact", "serde"] }
 ```
 
 Enable only the modules you need — unused features add zero dependencies.

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -4,7 +4,7 @@ Feature flag: `contact`
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["contact"] }
+arvo = { version = "0.9", features = ["contact"] }
 ```
 
 ---

--- a/docs/finance.md
+++ b/docs/finance.md
@@ -4,7 +4,7 @@ Feature flag: `finance`
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["finance"] }
+arvo = { version = "0.9", features = ["finance"] }
 ```
 
 ---

--- a/docs/geo.md
+++ b/docs/geo.md
@@ -4,7 +4,7 @@ Feature flag: `geo`
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["geo"] }
+arvo = { version = "0.9", features = ["geo"] }
 ```
 
 ---

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -4,7 +4,7 @@ Feature flag: `identifiers`
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["identifiers"] }
+arvo = { version = "0.9", features = ["identifiers"] }
 ```
 
 ---

--- a/docs/net.md
+++ b/docs/net.md
@@ -4,7 +4,7 @@ Feature flag: `net`
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["net"] }
+arvo = { version = "0.9", features = ["net"] }
 ```
 
 ---

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -4,7 +4,7 @@ Feature flag: `primitives`
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["primitives"] }
+arvo = { version = "0.9", features = ["primitives"] }
 ```
 
 ---

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -4,7 +4,7 @@ Feature flag: `temporal`
 
 ```toml
 [dependencies]
-arvo = { version = "0.8", features = ["temporal"] }
+arvo = { version = "0.9", features = ["temporal"] }
 ```
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! arvo = { version = "0.8", features = ["contact", "finance"] }
+//! arvo = { version = "0.9", features = ["contact", "finance"] }
 //! ```
 //!
 //! Available features: `contact`, `serde`, `full`.


### PR DESCRIPTION
## Summary

- Bumps crate version from `0.8.0` to `0.9.0`
- Updates version references in `README.md`, `src/lib.rs`, and all `docs/*.md` files

## What's in this release

- `measurement` feature: `Length`, `Weight`, `Temperature`, `Volume`, `Area`, `Speed`, `Pressure`, `Energy`, `Power`, `Frequency`

## Test plan

- [ ] CI passes
- [ ] `cargo check --features full,serde` succeeds
- [ ] Version in `Cargo.toml` is `0.9.0`